### PR TITLE
Retry if network fails

### DIFF
--- a/dld.js
+++ b/dld.js
@@ -16,15 +16,21 @@ var dld = function(uri, output_path, chunk_size) {
   };    
 
   var _getChunk = function (uri, from, size, cb) {
-    request({
-      uri: uri,
-      headers: {
-        'Range': 'bytes=' + from + '-' + parseInt(from + size - 1)
-      },
-      encoding: null
-    }, function (err, res, body) {
-      cb(body);
-    });
+    get();
+    function get() {
+      request({
+        uri: uri,
+        headers: {
+          'Range': 'bytes=' + from + '-' + parseInt(from + size - 1)
+        },
+        encoding: null
+      }, function (err, res, body) {
+        if (err || !res || res.statusCode !== 206) {
+          return get();
+        }
+        cb(body);
+      });
+    }
   };
 
   var _getPosition = function (filename, cb) {


### PR DESCRIPTION
When theres a slight network failure or timeout, dld freezes. This causes here 100% failure when trying to download big files and requires manual kill and restart to continue. 
